### PR TITLE
Added BASE_DOMAIN as .env variable, and updated to use APIv2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const p = require('phin');
 
 const target = process.argv[process.argv.length - 1];
+const domain = process.env.domain;
+
 const key = process.env.API_KEY;
 const baseDomain = process.env.BASE_DOMAIN || "https://kutt.it";
 
@@ -18,7 +20,7 @@ function getErrorMessage(message) {
 (async function() {
   try {
     const { body = {} } = await p({
-      url: `${baseDomain}/api/url/submit`,
+      url: `${baseDomain}/api/v2/links`,
       method: 'POST',
       data: { target },
       core: {
@@ -29,7 +31,7 @@ function getErrorMessage(message) {
       },
       parse: 'json'
     });
-    const message = body.shortUrl || getErrorMessage(body.error)
+    const message = body.link || getErrorMessage(body.error)
     console.log(message)
   } catch (error) {
     console.log(error.message);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const p = require('phin');
 
 const target = process.argv[process.argv.length - 1];
 const key = process.env.API_KEY;
+const baseDomain = process.env.BASE_DOMAIN || "https://kutt.it";
 
 if (!key) {
   return console.log('Please set an API key first.');
@@ -17,7 +18,7 @@ function getErrorMessage(message) {
 (async function() {
   try {
     const { body = {} } = await p({
-      url: 'https://kutt.it/api/url/submit',
+      url: `${baseDomain}/api/url/submit`,
       method: 'POST',
       data: { target },
       core: {


### PR DESCRIPTION
Allows users to more easily use workflow with custom domain. BASE_DOMAIN can be set alongside API_KEY. Falls back to "https://kutt.it" if no domain is set.